### PR TITLE
Replace `pin-util` with `pin-project-lite`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["scope", "future", "futures", "hrtb", "liftime"]
 include = ["**/*.rs", "Cargo.toml", "LICENSE-*"]
 
 [dependencies]
-pin-project-lite  = "0.2"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false, features = ["executor"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["scope", "future", "futures", "hrtb", "liftime"]
 include = ["**/*.rs", "Cargo.toml", "LICENSE-*"]
 
 [dependencies]
-pin-utils = "0.1"
+pin-project-lite  = "0.2"
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false, features = ["executor"] }


### PR DESCRIPTION
Both crates offer roughly work the same. Both crates have no dependencies.

The former crate is easy to misuse, and it does not seem to be maintained anymore. The latter crate is well maintained, well audited, and difficult to misuse.